### PR TITLE
unify build settings, add scripts to setup openssl and boost

### DIFF
--- a/ms/nghttp2_winrt8.1_universal/WinRTC/WinRTC.Windows/WinRTC.Windows.vcxproj
+++ b/ms/nghttp2_winrt8.1_universal/WinRTC/WinRTC.Windows/WinRTC.Windows.vcxproj
@@ -79,21 +79,27 @@
   <Import Project="..\WinRTC.Shared\WinRTC.Shared.vcxitems" Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <NuGetPackageImportStamp>1e5a9b6e</NuGetPackageImportStamp>
@@ -125,97 +131,103 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>C:\boost;%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);C:\Users\vivek\Documents\GitHub\openssl\inc32;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);openssl.lib;libeay32.lib;ssleay32.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-gd-1_58.lib;libboost_system-vc120-mt-gd-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>C:\Users\vivek\Documents\GitHub\openssl\vsout\NT-Store-8.1-Static-Unicode\Debug\Win32\bin;C:\boost\bin.v2\libs\system\build\msvc-12.0\debug\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Store\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-1_58.lib;libboost_system-vc120-mt-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Store\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);C:\Users\vivek\Documents\GitHub\openssl\inc32;C:\Users\vivek\Documents\GitHub\boost;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);openssl.lib;libeay32.lib;ssleay32.lib</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-gd-1_58.lib;libboost_system-vc120-mt-gd-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>C:\Users\vivek\Documents\GitHub\openssl\vsout\NT-Store-8.1-Static-Unicode\Debug\Win32\bin</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Store\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-1_58.lib;libboost_system-vc120-mt-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Store\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);C:\Users\vivek\Documents\GitHub\openssl\inc32;C:\Users\vivek\Documents\GitHub\boost;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);openssl.lib;libeay32.lib;ssleay32.lib</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-gd-1_58.lib;libboost_system-vc120-mt-gd-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>C:\Users\vivek\Documents\GitHub\openssl\vsout\NT-Store-8.1-Static-Unicode\Debug\Win32\bin</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Store\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-1_58.lib;libboost_system-vc120-mt-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Store\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-store</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/ms/nghttp2_winrt8.1_universal/WinRTC/WinRTC.WindowsPhone/WinRTC.WindowsPhone.vcxproj
+++ b/ms/nghttp2_winrt8.1_universal/WinRTC/WinRTC.WindowsPhone/WinRTC.WindowsPhone.vcxproj
@@ -61,15 +61,19 @@
   <Import Project="..\WinRTC.Shared\WinRTC.Shared.vcxitems" Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\build_dependencies.props" />
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
   </PropertyGroup>
@@ -87,58 +91,66 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);C:\Users\vivek\Documents\GitHub\openssl\inc32;C:\boost;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalDependencies>WindowsPhoneCore.lib;RuntimeObject.lib;PhoneAppModelHost.lib;%(AdditionalDependencies);openssl.lib;libeay32.lib;ssleay32.lib;ws2_32.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>C:\boost\bin.v2\libs\system\build\msvc-12.0\debug\link-static\threading-multi\windows-api-phone;C:\Users\vivek\Documents\GitHub\openssl\vsout\NT-Phone-8.1-Static-Unicode\Debug\Win32\bin</AdditionalLibraryDirectories>
+      <AdditionalDependencies>WindowsPhoneCore.lib;RuntimeObject.lib;PhoneAppModelHost.lib;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-gd-1_58.lib;libboost_system-vc120-mt-gd-1_58.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Phone\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>WindowsPhoneCore.lib;RuntimeObject.lib;PhoneAppModelHost.lib;;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-1_58.lib;libboost_system-vc120-mt-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Phone\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);C:\Users\vivek\Documents\GitHub\openssl\inc32;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>WindowsPhoneCore.lib;RuntimeObject.lib;PhoneAppModelHost.lib;;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-gd-1_58.lib;libboost_system-vc120-mt-gd-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Phone\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;BOOST_ASIO_WINDOWS_RUNTIME=1;BOOST_REGEX_NO_LIB=1;BOOST_DATE_TIME_NO_LIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);$(BOOST_HOME);$(OPENSSL_HOME)\include;$(SolutionDir)\..\..\examples;$(SolutionDir)\..\..\lib\includes;$(SolutionDir)\..\..\third-party</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>WindowsPhoneCore.lib;RuntimeObject.lib;PhoneAppModelHost.lib;;%(AdditionalDependencies);libeay32.lib;ssleay32.lib;ws2_32.lib;libboost_thread-vc120-mt-1_58.lib;libboost_system-vc120-mt-1_58.lib</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalLibraryDirectories>$(OPENSSL_HOME)\lib\Phone\8.1\Static\Unicode\$(Configuration)\$(Platform);$(BOOST_HOME)\bin.v2\libs\system\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone;$(BOOST_HOME)\bin.v2\libs\thread\build\msvc-12.0\$(Configuration)\architecture-$(PlatformShortName)\link-static\threading-multi\windows-api-phone</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/ms/nghttp2_winrt8.1_universal/WinRTC/build_dependencies.props
+++ b/ms/nghttp2_winrt8.1_universal/WinRTC/build_dependencies.props
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <BOOST_HOME>c:\dev\boost</BOOST_HOME>
+    <OPENSSL_HOME>c:\dev\openssl</OPENSSL_HOME>
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup>
+    <BuildMacro Include="BOOST_HOME">
+      <Value>$(BOOST_HOME)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OPENSSL_HOME">
+      <Value>$(OPENSSL_HOME)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/ms/nghttp2_winrt8.1_universal/WinRTC/build_dependencies.props
+++ b/ms/nghttp2_winrt8.1_universal/WinRTC/build_dependencies.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <BOOST_HOME>c:\dev\boost</BOOST_HOME>
-    <OPENSSL_HOME>c:\dev\openssl</OPENSSL_HOME>
+    <BOOST_HOME>c:\boost</BOOST_HOME>
+    <OPENSSL_HOME>c:\openssl</OPENSSL_HOME>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />

--- a/ms/setup/build_boost.bat
+++ b/ms/setup/build_boost.bat
@@ -1,0 +1,56 @@
+@echo off
+
+echo This script will build libs for the following configurations:
+echo        x86 - Windows Phone / Windows Store - Debug / Release
+echo        x64 - Windows Phone / Windows Store - Debug / Release
+echo        arm - Windows Phone / Windows Store - Debug / Release
+echo.
+echo Note that currently, the script only builds the thread library and
+echo any dependencies that thread requires.
+echo.
+echo This script assumes that you have followed the initial instructions
+echo found at: 
+echo    http://blogs.msdn.com/b/vcblog/archive/2014/07/18/using-boost-libraries-in-windows-store-and-phone-applications.aspx
+echo Specifically, the Download and Setup Boost Sources section, not the 
+echo Build section.
+echo.
+echo Additionally, it assumes that you have updated the version.hpp file
+echo located in $BOOST_HOME\libs\config\include\boost to the appropriate 
+echo version of Boost in the head repository.
+echo.
+echo Steven Gates' patches currently assume version 1.56 of boost.
+echo.
+echo To use this script run it from within the the base boost directory the 
+echo checkout above was run from.
+echo.
+echo If you have not, press Ctrl-C to stop, otherwise return to continue.
+pause
+
+if NOT EXIST bin.v2 GOTO NOBINV2
+@echo removing bin.v2
+del /s /q bin.v2
+rmdir /s /q bin.v2
+
+:NOBINV2
+
+@echo building x64 libs, store
+cd libs\thread\build
+b2 toolset=msvc-12.0 link=static link=shared windows-api=store architecture=x86 address-model=64 variant=release variant=debug
+move ..\..\..\bin.v2\libs\thread\build\msvc-12.0\debug\address-model-64\architecture-x86 ..\..\..\bin.v2\libs\thread\build\msvc-12.0\debug\architecture-x64
+rmdir /s /q ..\..\..\bin.v2\libs\thread\build\msvc-12.0\debug\address-model-64
+move ..\..\..\bin.v2\libs\thread\build\msvc-12.0\release\address-model-64\architecture-x86 ..\..\..\bin.v2\libs\thread\build\msvc-12.0\release\architecture-x64
+rmdir /s /q ..\..\..\bin.v2\libs\thread\build\msvc-12.0\release\address-model-64
+move ..\..\..\bin.v2\libs\chrono\build\msvc-12.0\debug\address-model-64\architecture-x86 ..\..\..\bin.v2\libs\chrono\build\msvc-12.0\debug\architecture-x64
+rmdir /s /q ..\..\..\bin.v2\libs\chrono\build\msvc-12.0\debug\address-model-64
+move ..\..\..\bin.v2\libs\chrono\build\msvc-12.0\release\address-model-64\architecture-x86 ..\..\..\bin.v2\libs\chrono\build\msvc-12.0\release\architecture-x64
+rmdir /s /q ..\..\..\bin.v2\libs\chrono\build\msvc-12.0\release\address-model-64
+move ..\..\..\bin.v2\libs\system\build\msvc-12.0\debug\address-model-64\architecture-x86 ..\..\..\bin.v2\libs\system\build\msvc-12.0\debug\architecture-x64
+rmdir /s /q ..\..\..\bin.v2\libs\system\build\msvc-12.0\debug\address-model-64
+move ..\..\..\bin.v2\libs\system\build\msvc-12.0\release\address-model-64\architecture-x86 ..\..\..\bin.v2\libs\system\build\msvc-12.0\release\architecture-x64
+rmdir /s /q ..\..\..\bin.v2\libs\system\build\msvc-12.0\release\address-model-64
+
+@echo building x86 and arm libs, phone and store
+b2 toolset=msvc-12.0 link=static link=shared windows-api=store windows-api=phone architecture=x86 architecture=arm variant=release variant=debug
+
+cd ..\..\..
+@echo done

--- a/ms/setup/build_openssl.bat
+++ b/ms/setup/build_openssl.bat
@@ -1,0 +1,75 @@
+@echo off
+
+echo This batch file will build OpenSSL for Windows Phone / Windows Store
+echo applications.  It assumes that you have already retrieved a version
+echo of OpenSSL from:
+echo    https://github.com/Microsoft/openssl
+echo into a directory.
+echo.
+echo It also assumes that you have installed prerequisites (like Perl)
+echo according to the INSTALL.WINAPP file.
+echo.
+echo You need to run this script from directory you cloned the above 
+echo repository into and specify the directory you wish the OpenSSL 
+echo libraries be installed into.
+echo.
+echo The script will create the following directory structure in the
+echo specified directory:
+echo.
+echo    bin\
+echo    lib\
+echo    include\
+echo.
+echo Press Control-C to stop or Enter to continue.
+pause
+
+if "%1" == "" goto USAGE
+if not exist "%1" goto NODIR
+
+del /s /q vsout
+rmdir /s /q vsout
+
+echo Creating solution file
+call ms\do_vsprojects.bat
+
+echo Building libs
+cd vsout
+msbuild NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj /p:Configuration="Release" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj /p:Configuration="Release" /p:Platform="x64" /verbosity:minimal
+msbuild NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="x64" /verbosity:minimal
+msbuild NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj /p:Configuration="Release" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Store-8.1-Static-Unicode\NT-Store-8.1-Static-Unicode.vcxproj /p:Configuration="Release" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Store-8.1-Static-Unicode\NT-Store-8.1-Static-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Store-8.1-Static-Unicode\NT-Store-8.1-Static-Unicode.vcxproj /p:Configuration="Release" /p:Platform="x64" /verbosity:minimal
+msbuild NT-Store-8.1-Static-Unicode\NT-Store-8.1-Static-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="x64" /verbosity:minimal
+msbuild NT-Store-8.1-Static-Unicode\NT-Store-8.1-Static-Unicode.vcxproj /p:Configuration="Release" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Store-8.1-Static-Unicode\NT-Store-8.1-Static-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Phone-8.1-Dll-Unicode\NT-Phone-8.1-Dll-Unicode.vcxproj /p:Configuration="Release" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Phone-8.1-Dll-Unicode\NT-Phone-8.1-Dll-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Phone-8.1-Dll-Unicode\NT-Phone-8.1-Dll-Unicode.vcxproj /p:Configuration="Release" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Phone-8.1-Dll-Unicode\NT-Phone-8.1-Dll-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Phone-8.1-Static-Unicode\NT-Phone-8.1-Static-Unicode.vcxproj /p:Configuration="Release" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Phone-8.1-Static-Unicode\NT-Phone-8.1-Static-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="x86" /verbosity:minimal
+msbuild NT-Phone-8.1-Static-Unicode\NT-Phone-8.1-Static-Unicode.vcxproj /p:Configuration="Release" /p:Platform="arm" /verbosity:minimal
+msbuild NT-Phone-8.1-Static-Unicode\NT-Phone-8.1-Static-Unicode.vcxproj /p:Configuration="Debug" /p:Platform="arm" /verbosity:minimal
+cd ..
+
+echo Packaging openssl
+call ms\do_packwinapp.bat
+
+echo Copying openssl to destination
+xcopy /e vsout\package\* %1\
+
+goto END
+
+:NODIR
+echo "%1" Does not exist.
+echo.
+
+:USAGE
+echo Command usage:
+echo "%0 <destination dir>"
+
+:END


### PR DESCRIPTION
The changes update the project files to build debug/release of both phone (x86/arm) and store (x86/x64/arm) versions.  Scripts help setup the necessary structure for openssl and boost.

Modify the settings in "ms/nghttp2_winrt8.1_universal/WinRTC/build_dependencies.props" to change OPENSSL_HOME and BOOST_HOME directories.